### PR TITLE
Add interactive empathy challenge page

### DIFF
--- a/assets/css/empathy-sim.css
+++ b/assets/css/empathy-sim.css
@@ -1,0 +1,389 @@
+.empathy-sim {
+  max-width: 60rem;
+  margin: 0 auto;
+  text-align: left;
+  padding: 2rem 0 4rem;
+}
+
+.empathy-hero {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.empathy-hero p {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 45ch;
+}
+
+.empathy-hero__cta {
+  font-weight: bold;
+}
+
+.empathy-section + .empathy-section {
+  margin-top: 3rem;
+}
+
+.empathy-section h2 {
+  text-align: left;
+  font-size: 1.5rem;
+  margin: 0 0 1rem;
+}
+
+.empathy-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.toggle-mapping {
+  border: 1px solid currentColor;
+  background: transparent;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.toggle-mapping[aria-expanded="true"] {
+  background: #111;
+  color: #fff;
+}
+
+.digit-mapping {
+  overflow-x: auto;
+  margin: 1rem 0 0;
+}
+
+.digit-mapping table {
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 20rem;
+}
+
+.digit-mapping th,
+.digit-mapping td {
+  border: 1px solid currentColor;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.long-mult {
+  margin-top: 1.5rem;
+  border: 1px solid currentColor;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.long-mult__problem {
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+.long-mult__row {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  font-size: 1.25rem;
+  letter-spacing: 0.1rem;
+}
+
+.long-mult__operator {
+  width: 1.5rem;
+  text-align: center;
+}
+
+.long-mult__divider {
+  border-bottom: 1px solid currentColor;
+  margin-top: 0.5rem;
+}
+
+.long-mult__workspace {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(4.5rem, 1fr));
+  gap: 0.75rem;
+}
+
+.long-mult__column {
+  display: grid;
+  grid-template-rows: repeat(4, minmax(2.5rem, auto));
+  gap: 0.25rem;
+}
+
+.long-mult input {
+  text-transform: uppercase;
+  text-align: center;
+  padding: 0.5rem;
+  border: 1px solid #111;
+  font-size: 1.125rem;
+  border-radius: 0.25rem;
+}
+
+.long-mult input[aria-invalid="true"] {
+  border-color: #b91c1c;
+  background: #fee2e2;
+}
+
+.long-mult input[aria-invalid="false"] {
+  border-color: #15803d;
+  background: #dcfce7;
+}
+
+.empathy-note {
+  min-height: 2rem;
+  margin-top: 1rem;
+  font-style: italic;
+}
+
+.fractions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.fraction-card {
+  flex: 1 1 12rem;
+  border: 1px solid currentColor;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.fraction-card label {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.fraction-card input {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #111;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.fraction-card__given {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.fraction-compare {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.fraction-compare select,
+.fraction-compare button {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  border-radius: 0.25rem;
+  font-family: inherit;
+}
+
+.relational {
+  border: 1px solid currentColor;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
+
+.relational__selectors {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.relational select {
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #111;
+  min-width: 10rem;
+}
+
+.relational__symbol {
+  font-size: 2rem;
+}
+
+.relational button {
+  margin-right: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.balance {
+  margin-top: 1.5rem;
+  height: 6rem;
+  display: flex;
+  justify-content: center;
+}
+
+.balance__arm {
+  position: relative;
+  width: min(24rem, 90%);
+  height: 100%;
+  border-top: 4px solid currentColor;
+  transition: transform 0.8s ease;
+}
+
+.balance.visualize .balance__arm {
+  transform: rotate(0deg);
+}
+
+.balance.tilt-left .balance__arm {
+  transform: rotate(-6deg);
+}
+
+.balance.tilt-right .balance__arm {
+  transform: rotate(6deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .balance__arm {
+    transition: none;
+  }
+}
+
+.balance__pivot {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 0;
+  height: 0;
+  border-left: 0.75rem solid transparent;
+  border-right: 0.75rem solid transparent;
+  border-top: 1.5rem solid currentColor;
+}
+
+.balance__pan {
+  position: absolute;
+  width: 5rem;
+  height: 1.25rem;
+  border: 2px solid currentColor;
+  border-radius: 0 0 2rem 2rem;
+  top: -0.125rem;
+}
+
+.balance__pan--left {
+  left: 10%;
+}
+
+.balance__pan--right {
+  right: 10%;
+}
+
+.stepper {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.stepper__step {
+  border: 1px solid currentColor;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.stepper__step[aria-disabled="true"] {
+  opacity: 0.6;
+}
+
+.stepper__prompt p {
+  margin: 0 0 0.75rem;
+}
+
+.stepper__hint {
+  font-size: 0.875rem;
+  font-style: italic;
+  margin: 0;
+}
+
+.stepper input {
+  margin-right: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #111;
+  text-transform: uppercase;
+}
+
+.hint-button {
+  border: 1px solid currentColor;
+  background: transparent;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.empathy-footer {
+  margin-top: 4rem;
+  border-top: 1px solid currentColor;
+  padding-top: 2rem;
+}
+
+.empathy-footer h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.empathy-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
+}
+
+.empathy-stats div {
+  border: 1px solid currentColor;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.empathy-stats dt {
+  font-weight: bold;
+  margin: 0 0 0.5rem;
+  font-style: normal;
+}
+
+.empathy-stats dd {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .long-mult__workspace {
+    grid-template-columns: repeat(2, minmax(4rem, 1fr));
+  }
+
+  .long-mult__column {
+    grid-template-rows: repeat(4, minmax(2.25rem, auto));
+  }
+}

--- a/assets/js/empathy-sim.js
+++ b/assets/js/empathy-sim.js
@@ -1,0 +1,590 @@
+(() => {
+  const baseLetters = ['Z', 'A', 'B', 'C', 'D', 'E'];
+  const letterSet = new Set(baseLetters);
+
+  const empathyState = {
+    attempts: 0,
+    errors: 0,
+    completed: {
+      baseSix: false,
+      fractions: false,
+      relational: false,
+      proportion: false,
+    },
+    progress: {
+      baseSix: 'fresh',
+      fractions: 'fresh',
+      relational: 'fresh',
+      proportion: 'fresh',
+    },
+    timers: {},
+    timeSpent: {
+      baseSix: 0,
+      fractions: 0,
+      relational: 0,
+      proportion: 0,
+    },
+  };
+
+  const statsNodes = {
+    complete: document.getElementById('stat-complete'),
+    attempts: document.getElementById('stat-attempts'),
+    errors: document.getElementById('stat-errors'),
+    time: document.getElementById('stat-time'),
+  };
+
+  function startTimer(exercise) {
+    if (!empathyState.timers[exercise]) {
+      empathyState.timers[exercise] = Date.now();
+    }
+  }
+
+  function stopTimer(exercise) {
+    if (empathyState.timers[exercise]) {
+      empathyState.timeSpent[exercise] += Date.now() - empathyState.timers[exercise];
+      delete empathyState.timers[exercise];
+      updateStats();
+    }
+  }
+
+  function formatDuration(ms) {
+    const totalSeconds = Math.round(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+  }
+
+  function updateStats() {
+    if (!statsNodes.complete) {
+      return;
+    }
+    const completedCount = Object.values(empathyState.completed).filter(Boolean).length;
+    statsNodes.complete.textContent = `${completedCount} / 4`;
+    statsNodes.attempts.textContent = empathyState.attempts;
+    statsNodes.errors.textContent = empathyState.errors;
+    let total = Object.values(empathyState.timeSpent).reduce((acc, value) => acc + value, 0);
+    for (const key of Object.keys(empathyState.timers)) {
+      total += Date.now() - empathyState.timers[key];
+    }
+    statsNodes.time.textContent = formatDuration(total);
+  }
+
+  function recordStatus(exercise, status, incorrectCount = 0) {
+    const previous = empathyState.progress[exercise] || 'fresh';
+    empathyState.progress[exercise] = status;
+
+    if (status === 'passed') {
+      if (previous === 'fresh' || previous === 'incomplete') {
+        empathyState.attempts += 1;
+      }
+      empathyState.completed[exercise] = true;
+      stopTimer(exercise);
+    } else if (status === 'attempted') {
+      if (previous === 'fresh' || previous === 'incomplete') {
+        empathyState.attempts += 1;
+      }
+      empathyState.errors += incorrectCount;
+    } else if (status === 'incomplete' && previous === 'fresh') {
+      empathyState.completed[exercise] = false;
+    }
+    updateStats();
+  }
+
+  function sanitizeInput(input) {
+    const raw = input.value.toUpperCase().replace(/[^A-Z]/g, '');
+    if (raw !== input.value) {
+      input.value = raw;
+    }
+    return raw;
+  }
+
+  function toggleMapping() {
+    const toggleButton = document.querySelector('.toggle-mapping');
+    const mapping = document.getElementById('digit-mapping');
+    if (!toggleButton || !mapping) {
+      return;
+    }
+    toggleButton.addEventListener('click', () => {
+      const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+      toggleButton.setAttribute('aria-expanded', String(!expanded));
+      if (expanded) {
+        mapping.hidden = true;
+        toggleButton.textContent = 'Show digit mapping';
+      } else {
+        mapping.hidden = false;
+        toggleButton.textContent = 'Hide digit mapping';
+      }
+    });
+  }
+
+  function initBaseSixExercise() {
+    const container = document.querySelector('[data-exercise="base-six"]');
+    if (!container) {
+      return;
+    }
+
+    const expected = {
+      carries: ['', 'A', 'B', ''],
+      rows: [
+        ['', 'B', 'B', 'C'],
+        ['A', 'C', 'D', ''],
+      ],
+      final: ['B', 'Z', 'Z', 'C'],
+    };
+
+    const inputs = Array.from(container.querySelectorAll('input'));
+
+    container.addEventListener('focusin', () => startTimer('baseSix'));
+
+    inputs.forEach((input) => {
+      input.addEventListener('input', () => {
+        sanitizeInput(input);
+        evaluate();
+      });
+    });
+
+    function evaluate() {
+      let missing = 0;
+      let incorrect = 0;
+
+      const message = container.querySelector('[data-feedback="base-six"]');
+
+      const fields = {
+        carries: container.querySelectorAll('[data-role="carry"]'),
+        rows: [
+          container.querySelectorAll('[data-row="0"]'),
+          container.querySelectorAll('[data-row="1"]'),
+        ],
+        final: container.querySelectorAll('[data-role="final"]'),
+      };
+
+      const checkValue = (inputEl, expectedValue) => {
+        const value = sanitizeInput(inputEl);
+        if (!value) {
+          if (expectedValue) {
+            inputEl.removeAttribute('aria-invalid');
+            missing += 1;
+          } else {
+            inputEl.removeAttribute('aria-invalid');
+          }
+          return;
+        }
+        if (!letterSet.has(value)) {
+          inputEl.setAttribute('aria-invalid', 'true');
+          incorrect += 1;
+          return;
+        }
+        if (!expectedValue) {
+          inputEl.setAttribute('aria-invalid', 'true');
+          incorrect += 1;
+          return;
+        }
+        if (value === expectedValue) {
+          inputEl.setAttribute('aria-invalid', 'false');
+        } else {
+          inputEl.setAttribute('aria-invalid', 'true');
+          incorrect += 1;
+        }
+      };
+
+      fields.carries.forEach((inputEl, index) => {
+        checkValue(inputEl, expected.carries[index]);
+      });
+
+      fields.rows.forEach((rowInputs, rowIndex) => {
+        rowInputs.forEach((inputEl, columnIndex) => {
+          checkValue(inputEl, expected.rows[rowIndex][columnIndex]);
+        });
+      });
+
+      fields.final.forEach((inputEl, index) => {
+        checkValue(inputEl, expected.final[index]);
+      });
+
+      if (missing > 0) {
+        if (message) {
+          message.textContent = 'There are still open cells. Notice where the carries stack up.';
+        }
+        recordStatus('baseSix', 'incomplete');
+        return;
+      }
+
+      if (incorrect > 0) {
+        if (message) {
+          message.textContent = 'Something is off. Which column felt the most awkward when the letters carried over?';
+        }
+        recordStatus('baseSix', 'attempted', incorrect);
+        return;
+      }
+
+      if (message) {
+        message.textContent = 'Nice! Hold onto how much thinking it took to stay in this unfamiliar place.';
+      }
+      recordStatus('baseSix', 'passed');
+    }
+  }
+
+  function initFractionsExercise() {
+    const container = document.querySelector('[data-exercise="fractions"]');
+    if (!container) {
+      return;
+    }
+    const numeratorOne = document.getElementById('fraction-1-numerator');
+    const denominatorOne = document.getElementById('fraction-1-denominator');
+    const numeratorTwo = document.getElementById('fraction-2-numerator');
+    const denominatorTwo = document.getElementById('fraction-2-denominator');
+    const comparisonSelect = document.getElementById('fraction-comparison');
+    const checkButton = document.getElementById('fraction-check');
+    const message = document.querySelector('[data-feedback="fractions"]');
+
+    const inputs = [numeratorOne, denominatorOne, numeratorTwo, denominatorTwo].filter(Boolean);
+
+    container.addEventListener('focusin', () => startTimer('fractions'));
+
+    inputs.forEach((input) => {
+      input.addEventListener('input', () => {
+        const value = sanitizeInput(input);
+        if (value && ![...value].every((char) => letterSet.has(char))) {
+          input.setAttribute('aria-invalid', 'true');
+        } else {
+          input.removeAttribute('aria-invalid');
+        }
+        updateControls();
+      });
+    });
+
+    function updateControls() {
+      const denom1 = denominatorOne ? denominatorOne.value : '';
+      const denom2 = denominatorTwo ? denominatorTwo.value : '';
+      const ready = denom1 && denom2 && denom1 === denom2;
+      comparisonSelect.disabled = !ready;
+      checkButton.disabled = !ready;
+      if (!ready) {
+        comparisonSelect.value = '';
+      }
+    }
+
+    checkButton.addEventListener('click', () => {
+      const values = {
+        n1: numeratorOne ? sanitizeInput(numeratorOne) : '',
+        d1: denominatorOne ? sanitizeInput(denominatorOne) : '',
+        n2: numeratorTwo ? sanitizeInput(numeratorTwo) : '',
+        d2: denominatorTwo ? sanitizeInput(denominatorTwo) : '',
+      };
+
+      let incorrect = 0;
+
+      const expected = {
+        n1: 'AD',
+        d: 'BC',
+        n2: 'BZ',
+      };
+
+      const allLettersValid = Object.values(values).every((text) =>
+        [...text].every((char) => letterSet.has(char)),
+      );
+
+      if (!allLettersValid) {
+        if (message) {
+          message.textContent = 'Those symbols slip back toward base ten. Stay with the alien digits from the first task.';
+        }
+        recordStatus('fractions', 'attempted', 1);
+        return;
+      }
+
+      if (values.d1 !== expected.d || values.d2 !== expected.d) {
+        if (message) {
+          message.textContent = 'The gate stays closed until both denominators read BC. Check how you scaled each fraction.';
+        }
+        if (denominatorOne) {
+          denominatorOne.setAttribute('aria-invalid', values.d1 === expected.d ? 'false' : 'true');
+        }
+        if (denominatorTwo) {
+          denominatorTwo.setAttribute('aria-invalid', values.d2 === expected.d ? 'false' : 'true');
+        }
+        incorrect += 1;
+        recordStatus('fractions', 'attempted', incorrect);
+        return;
+      }
+
+      if (numeratorOne) {
+        numeratorOne.setAttribute('aria-invalid', values.n1 === expected.n1 ? 'false' : 'true');
+        if (values.n1 !== expected.n1) {
+          incorrect += 1;
+        }
+      }
+      if (numeratorTwo) {
+        numeratorTwo.setAttribute('aria-invalid', values.n2 === expected.n2 ? 'false' : 'true');
+        if (values.n2 !== expected.n2) {
+          incorrect += 1;
+        }
+      }
+
+      if (incorrect > 0) {
+        if (message) {
+          message.textContent = 'Try re-building the path from numerator to denominator. Where did the scaling go sideways?';
+        }
+        recordStatus('fractions', 'attempted', incorrect);
+        return;
+      }
+
+      if (!comparisonSelect.value) {
+        if (message) {
+          message.textContent = 'Now decide who leaves the gate first. Pick a relationship.';
+        }
+        recordStatus('fractions', 'incomplete');
+        return;
+      }
+
+      if (comparisonSelect.value !== 'gt') {
+        if (message) {
+          message.textContent = 'Look back at the converted numerators: BZ stays ahead of AD. Sit with why the larger number still feels unfamiliar.';
+        }
+        recordStatus('fractions', 'attempted', 1);
+        return;
+      }
+
+      if (message) {
+        message.textContent = 'You lined up every piece. Remember how deliberate you had to be just to compare two fractions.';
+      }
+      recordStatus('fractions', 'passed');
+    });
+  }
+
+  function expressionValue(expression) {
+    if (!expression) {
+      return null;
+    }
+    const trimmed = expression.trim();
+    if (trimmed.includes('+')) {
+      const [left, right] = trimmed.split('+').map((part) => part.trim());
+      return expressionValue(left) + expressionValue(right);
+    }
+    if (trimmed.includes('×')) {
+      const [left, right] = trimmed.split('×').map((part) => part.trim());
+      return expressionValue(left) * expressionValue(right);
+    }
+    if (trimmed.includes('−')) {
+      const [left, right] = trimmed.split('−').map((part) => part.trim());
+      return expressionValue(left) - expressionValue(right);
+    }
+    const letters = [...trimmed];
+    if (!letters.every((char) => letterSet.has(char))) {
+      return null;
+    }
+    return letters.reduce((acc, char) => acc * 6 + baseLetters.indexOf(char), 0);
+  }
+
+  function hasOperator(expression) {
+    return /[+×−]/.test(expression || '');
+  }
+
+  function initRelationalExercise() {
+    const container = document.querySelector('[data-exercise="relational"]');
+    if (!container) {
+      return;
+    }
+    const leftSelect = document.getElementById('relational-left');
+    const rightSelect = document.getElementById('relational-right');
+    const checkButton = document.getElementById('relational-check');
+    const visualizeButton = document.getElementById('relational-visualize');
+    const balance = container.querySelector('.balance');
+    const message = document.querySelector('[data-feedback="relational"]');
+
+    const start = () => startTimer('relational');
+    leftSelect.addEventListener('change', start);
+    rightSelect.addEventListener('change', start);
+
+    checkButton.addEventListener('click', () => {
+      const leftValue = expressionValue(leftSelect.value);
+      const rightValue = expressionValue(rightSelect.value);
+
+      if (!leftSelect.value || !rightSelect.value) {
+        if (message) {
+          message.textContent = 'Choose an expression for both pans of the scale first.';
+        }
+        recordStatus('relational', 'incomplete');
+        return;
+      }
+
+      if (leftValue === null || rightValue === null) {
+        if (message) {
+          message.textContent = 'One of the selections pulled in digits outside the alien set. Reset with Z through E only.';
+        }
+        recordStatus('relational', 'attempted', 1);
+        return;
+      }
+
+      if (leftValue === rightValue && hasOperator(leftSelect.value) && hasOperator(rightSelect.value)) {
+        if (message) {
+          message.textContent = 'That balance feels different than an answer. Equality can describe a relationship.';
+        }
+        recordStatus('relational', 'passed');
+        return;
+      }
+
+      if (leftValue === rightValue) {
+        if (message) {
+          message.textContent = 'You made the numbers match, but one side collapsed into a single value. That rush to solve is the struggle students feel.';
+        }
+        recordStatus('relational', 'attempted', 1);
+        return;
+      }
+
+      if (message) {
+        message.textContent = 'The scale still tilts. Revisit which quantities belong together before equating them.';
+      }
+      recordStatus('relational', 'attempted', 1);
+    });
+
+    visualizeButton.addEventListener('click', () => {
+      const leftValue = expressionValue(leftSelect.value);
+      const rightValue = expressionValue(rightSelect.value);
+      if (!balance) {
+        return;
+      }
+      balance.classList.remove('visualize', 'tilt-left', 'tilt-right');
+      if (leftValue === null || rightValue === null) {
+        balance.classList.add('tilt-left');
+        return;
+      }
+      if (leftValue === rightValue) {
+        balance.classList.add('visualize');
+      } else if (leftValue > rightValue) {
+        balance.classList.add('tilt-left');
+      } else {
+        balance.classList.add('tilt-right');
+      }
+    });
+  }
+
+  function initProportionExercise() {
+    const stepper = document.querySelector('[data-exercise="proportion"]');
+    if (!stepper) {
+      return;
+    }
+
+    const steps = [
+      { id: 'proportion-step-1', expected: 'S', next: 2 },
+      { id: 'proportion-step-2', expected: 'S', next: 3 },
+      { id: 'proportion-step-3', expected: 'BZ', next: 4 },
+      { id: 'proportion-step-4', expected: 'D', next: null },
+    ];
+
+    stepper.addEventListener('focusin', () => startTimer('proportion'));
+
+    const message = document.querySelector('[data-feedback="proportion"]');
+
+    steps.forEach((step, index) => {
+      const input = document.getElementById(step.id);
+      const stepElement = stepper.querySelector(`[data-step="${index + 1}"]`);
+      if (!input || !stepElement) {
+        return;
+      }
+      input.addEventListener('input', () => {
+        const value = sanitizeInput(input);
+        if (value.length === step.expected.length) {
+          if (value === step.expected) {
+            input.setAttribute('aria-invalid', 'false');
+            stepElement.setAttribute('aria-disabled', 'false');
+            unlockNext(step.next);
+            if (step.next === null) {
+              evaluateFinal();
+            }
+          } else {
+            input.setAttribute('aria-invalid', 'true');
+            if (step.next !== null) {
+              lockStep(step.next);
+            }
+          }
+        } else {
+          input.removeAttribute('aria-invalid');
+        }
+      });
+    });
+
+    const hintButtons = stepper.querySelectorAll('.hint-button');
+    hintButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const hintId = button.getAttribute('data-hint');
+        const hint = stepper.querySelector(`[data-step="${hintId}"] .stepper__hint`);
+        if (hint) {
+          hint.hidden = false;
+        }
+      });
+    });
+
+    function lockStep(stepNumber) {
+      if (!stepNumber) {
+        return;
+      }
+      const target = stepper.querySelector(`[data-step="${stepNumber}"]`);
+      if (!target) {
+        return;
+      }
+      target.setAttribute('aria-disabled', 'true');
+      const input = target.querySelector('input');
+      const hintButton = target.querySelector('.hint-button');
+      if (input) {
+        input.value = '';
+        input.setAttribute('disabled', '');
+        input.removeAttribute('aria-invalid');
+      }
+      if (hintButton) {
+        hintButton.setAttribute('disabled', '');
+      }
+    }
+
+    function unlockNext(stepNumber) {
+      if (!stepNumber) {
+        evaluateFinal();
+        return;
+      }
+      const target = stepper.querySelector(`[data-step="${stepNumber}"]`);
+      if (!target) {
+        return;
+      }
+      target.removeAttribute('aria-disabled');
+      const input = target.querySelector('input');
+      const hintButton = target.querySelector('.hint-button');
+      if (input) {
+        input.removeAttribute('disabled');
+      }
+      if (hintButton) {
+        hintButton.removeAttribute('disabled');
+      }
+    }
+
+    function evaluateFinal() {
+      const values = steps.map((step) => {
+        const input = document.getElementById(step.id);
+        return input ? sanitizeInput(input) : '';
+      });
+
+      if (values.some((value, index) => value !== steps[index].expected)) {
+        if (message) {
+          message.textContent = 'Trace the chain again—one shaky letter earlier throws off the final quotient.';
+        }
+        recordStatus('proportion', 'attempted', 1);
+        return;
+      }
+
+      if (message) {
+        message.textContent = 'Proportion solved. Notice how every earlier struggle fed into this final answer.';
+      }
+      recordStatus('proportion', 'passed');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    toggleMapping();
+    initBaseSixExercise();
+    initFractionsExercise();
+    initRelationalExercise();
+    initProportionExercise();
+    updateStats();
+  });
+})();

--- a/empathy-challenge.html
+++ b/empathy-challenge.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Y0Q6E6Q62N"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-Y0Q6E6Q62N');
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compounding Empathy Challenge</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="assets/css/empathy-sim.css">
+</head>
+<body>
+  <main class="empathy-sim">
+    <header class="empathy-hero">
+      <h1 class="gradient-text">Compounding Empathy Challenge</h1>
+      <p>
+        Step inside the frustration students feel when the number system and the language around equality shift under
+your feet.
+        Each task reuses the same six-letter digit set, so the discomfort compounds just like it does in the classroom.
+      </p>
+      <p class="empathy-hero__cta">Work through each activity. Pause when you feel the friction.</p>
+    </header>
+
+    <section class="empathy-section" id="base-six">
+      <div class="empathy-section__header">
+        <h2>1. Base-Six Multiplication</h2>
+        <button type="button" class="toggle-mapping" aria-expanded="false" aria-controls="digit-mapping">Show digit
+mapping</button>
+      </div>
+      <p>
+        Multiply the two alien numbers using long multiplication. Fill in the carries and partial products using the
+letters for the base-six digits.
+        When you think you're done, tab to the final product and check your work.
+      </p>
+      <div class="digit-mapping" id="digit-mapping" hidden>
+        <table>
+          <caption>Digit mapping between alien letters and base-ten values</caption>
+          <thead>
+            <tr>
+              <th scope="col">Letter</th>
+              <th scope="col">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Z</td><td>0</td></tr>
+            <tr><td>A</td><td>1</td></tr>
+            <tr><td>B</td><td>2</td></tr>
+            <tr><td>C</td><td>3</td></tr>
+            <tr><td>D</td><td>4</td></tr>
+            <tr><td>E</td><td>5</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="long-mult" data-exercise="base-six">
+        <div class="long-mult__problem" aria-label="Long multiplication setup">
+          <div class="long-mult__row long-mult__row--given"><span class="long-mult__operator">&nbsp;</span><span
+class="long-mult__value">D</span><span class="long-mult__value">E</span></div>
+          <div class="long-mult__row long-mult__row--given"><span class="long-mult__operator">&times;</span><span
+class="long-mult__value">B</span><span class="long-mult__value">C</span></div>
+          <div class="long-mult__divider" aria-hidden="true"></div>
+        </div>
+        <div class="long-mult__workspace" role="group" aria-label="Workspace for carries and partial products">
+          <div class="long-mult__column" data-column="0">
+            <label class="sr-only" for="base-six-carry-0">Carry column 1</label>
+            <input id="base-six-carry-0" data-role="carry" maxlength="1" inputmode="text" autocomplete="off">
+            <label class="sr-only" for="base-six-row1-0">Partial product column 1</label>
+            <input id="base-six-row1-0" data-role="row" data-row="0" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-row2-0">Shifted partial product column 1</label>
+            <input id="base-six-row2-0" data-role="row" data-row="1" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-final-0">Final product column 1</label>
+            <input id="base-six-final-0" data-role="final" maxlength="1" inputmode="text" autocomplete="off">
+          </div>
+          <div class="long-mult__column" data-column="1">
+            <label class="sr-only" for="base-six-carry-1">Carry column 2</label>
+            <input id="base-six-carry-1" data-role="carry" maxlength="1" inputmode="text" autocomplete="off">
+            <label class="sr-only" for="base-six-row1-1">Partial product column 2</label>
+            <input id="base-six-row1-1" data-role="row" data-row="0" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-row2-1">Shifted partial product column 2</label>
+            <input id="base-six-row2-1" data-role="row" data-row="1" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-final-1">Final product column 2</label>
+            <input id="base-six-final-1" data-role="final" maxlength="1" inputmode="text" autocomplete="off">
+          </div>
+          <div class="long-mult__column" data-column="2">
+            <label class="sr-only" for="base-six-carry-2">Carry column 3</label>
+            <input id="base-six-carry-2" data-role="carry" maxlength="1" inputmode="text" autocomplete="off">
+            <label class="sr-only" for="base-six-row1-2">Partial product column 3</label>
+            <input id="base-six-row1-2" data-role="row" data-row="0" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-row2-2">Shifted partial product column 3</label>
+            <input id="base-six-row2-2" data-role="row" data-row="1" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-final-2">Final product column 3</label>
+            <input id="base-six-final-2" data-role="final" maxlength="1" inputmode="text" autocomplete="off">
+          </div>
+          <div class="long-mult__column" data-column="3">
+            <label class="sr-only" for="base-six-carry-3">Carry column 4</label>
+            <input id="base-six-carry-3" data-role="carry" maxlength="1" inputmode="text" autocomplete="off">
+            <label class="sr-only" for="base-six-row1-3">Partial product column 4</label>
+            <input id="base-six-row1-3" data-role="row" data-row="0" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-row2-3">Shifted partial product column 4</label>
+            <input id="base-six-row2-3" data-role="row" data-row="1" maxlength="1" inputmode="text"
+autocomplete="off">
+            <label class="sr-only" for="base-six-final-3">Final product column 4</label>
+            <input id="base-six-final-3" data-role="final" maxlength="1" inputmode="text" autocomplete="off">
+          </div>
+        </div>
+        <p class="empathy-note" data-feedback="base-six" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <section class="empathy-section" id="fractions">
+      <h2>2. Fractions as Gatekeepers</h2>
+      <p>
+        Two students reach the same gate at the same time. Neither can pass until the denominators match. Convert each
+fraction with the alien digits and then decide which one is larger.
+      </p>
+      <div class="fractions" data-exercise="fractions" role="group" aria-label="Fraction conversion workspace">
+        <div class="fraction-card">
+          <p class="fraction-card__given"><span>B</span>/<span>C</span></p>
+          <label for="fraction-1-numerator">Converted numerator</label>
+          <input id="fraction-1-numerator" maxlength="2" autocomplete="off">
+          <label for="fraction-1-denominator">Converted denominator</label>
+          <input id="fraction-1-denominator" maxlength="2" autocomplete="off">
+        </div>
+        <div class="fraction-card">
+          <p class="fraction-card__given"><span>D</span>/<span>E</span></p>
+          <label for="fraction-2-numerator">Converted numerator</label>
+          <input id="fraction-2-numerator" maxlength="2" autocomplete="off">
+          <label for="fraction-2-denominator">Converted denominator</label>
+          <input id="fraction-2-denominator" maxlength="2" autocomplete="off">
+        </div>
+      </div>
+      <div class="fraction-compare">
+        <label for="fraction-comparison">Select the relationship once the denominators match</label>
+        <select id="fraction-comparison" disabled>
+          <option value="">Choose…</option>
+          <option value="lt">First fraction is smaller</option>
+          <option value="eq">Fractions are equal</option>
+          <option value="gt">First fraction is larger</option>
+        </select>
+        <button type="button" id="fraction-check" disabled>Check comparison</button>
+      </div>
+      <p class="empathy-note" data-feedback="fractions" aria-live="polite"></p>
+    </section>
+
+    <section class="empathy-section" id="relational-equals">
+      <h2>3. Relational Equals</h2>
+      <p>
+        Choose two expressions that mean the same quantity without collapsing either side into a single answer. Listen for
+your own temptation to turn “equals” into “do the operation.”
+      </p>
+      <div class="relational" data-exercise="relational">
+        <div class="relational__selectors" role="group" aria-label="Relational equality builder">
+          <div>
+            <label for="relational-left">Left side</label>
+            <select id="relational-left">
+              <option value="">Select…</option>
+              <option value="B+B">B + B</option>
+              <option value="C+A">C + A</option>
+              <option value="D">D</option>
+              <option value="C×B">C × B</option>
+              <option value="AZ">AZ</option>
+              <option value="E-B">E − B</option>
+              <option value="B+C">B + C</option>
+              <option value="E">E</option>
+            </select>
+          </div>
+          <span class="relational__symbol" aria-hidden="true">⇔</span>
+          <div>
+            <label for="relational-right">Right side</label>
+            <select id="relational-right">
+              <option value="">Select…</option>
+              <option value="B+B">B + B</option>
+              <option value="C+A">C + A</option>
+              <option value="D">D</option>
+              <option value="C×B">C × B</option>
+              <option value="AZ">AZ</option>
+              <option value="E-B">E − B</option>
+              <option value="B+C">B + C</option>
+              <option value="E">E</option>
+            </select>
+          </div>
+        </div>
+        <button type="button" id="relational-check">Check relationship</button>
+        <button type="button" id="relational-visualize">Show me why</button>
+        <div class="balance" aria-hidden="true">
+          <div class="balance__arm">
+            <div class="balance__pan balance__pan--left"></div>
+            <div class="balance__pivot"></div>
+            <div class="balance__pan balance__pan--right"></div>
+          </div>
+        </div>
+      </div>
+      <p class="empathy-note" data-feedback="relational" aria-live="polite"></p>
+    </section>
+
+    <section class="empathy-section" id="proportion">
+      <h2>4. Proportional Reasoning Capstone</h2>
+      <p>
+        You are planning snacks for an alien exchange. Their recipe uses <strong>B</strong> scoops of sweet dust for
+every <strong>C</strong> scoops of grain. How much sweet dust keeps the taste right when you have <strong>AZ</strong> scoops of
+grain?
+        Walk through each step using the letter <strong>S</strong> for the unknown amount. Your progress unlocks the next
+prompt.
+      </p>
+      <ol class="stepper" data-exercise="proportion">
+        <li class="stepper__step" data-step="1">
+          <div class="stepper__prompt">
+            <p>Step 1. Complete the proportion: <span class="math">B / C = ___ / AZ</span></p>
+            <p class="stepper__hint" hidden>Keep sugar over grain on both sides. The letters from the multiplication
+exercise still apply.</p>
+          </div>
+          <label for="proportion-step-1" class="sr-only">Missing symbol in the proportion</label>
+          <input id="proportion-step-1" maxlength="1" autocomplete="off">
+          <button type="button" class="hint-button" data-hint="1">Need a hint?</button>
+        </li>
+        <li class="stepper__step" data-step="2" aria-disabled="true">
+          <div class="stepper__prompt">
+            <p>Step 2. Cross-multiply: <span class="math">B × AZ = C × ___</span></p>
+            <p class="stepper__hint" hidden>Remember what you put in the blank above. If you switch to base ten, the
+balance tips.</p>
+          </div>
+          <label for="proportion-step-2" class="sr-only">Missing symbol in cross multiplication</label>
+          <input id="proportion-step-2" maxlength="1" autocomplete="off" disabled>
+          <button type="button" class="hint-button" data-hint="2" disabled>Need a hint?</button>
+        </li>
+        <li class="stepper__step" data-step="3" aria-disabled="true">
+          <div class="stepper__prompt">
+            <p>Step 3. Compute the left side product in alien digits.</p>
+            <p class="stepper__hint" hidden>This is the same as multiplying B by AZ from the first exercise. Watch for
+carries.</p>
+          </div>
+          <label for="proportion-step-3" class="sr-only">Result of B times AZ in base six letters</label>
+          <input id="proportion-step-3" maxlength="2" autocomplete="off" disabled>
+          <button type="button" class="hint-button" data-hint="3" disabled>Need a hint?</button>
+        </li>
+        <li class="stepper__step" data-step="4" aria-disabled="true">
+          <div class="stepper__prompt">
+            <p>Step 4. Divide by C to solve for the unknown.</p>
+            <p class="stepper__hint" hidden>You're almost there. Does your answer match the story the fractions were
+trying to tell?</p>
+          </div>
+          <label for="proportion-step-4" class="sr-only">Amount of sweet dust for AZ scoops of grain</label>
+          <input id="proportion-step-4" maxlength="1" autocomplete="off" disabled>
+          <button type="button" class="hint-button" data-hint="4" disabled>Need a hint?</button>
+        </li>
+      </ol>
+      <p class="empathy-note" data-feedback="proportion" aria-live="polite"></p>
+    </section>
+
+    <footer class="empathy-footer">
+      <h2>Your empathy log</h2>
+      <p>The tracker below summarizes your attempts, error corrections, and total focused time across the activities.</p>
+      <dl class="empathy-stats">
+        <div>
+          <dt>Exercises completed</dt>
+          <dd id="stat-complete">0 / 4</dd>
+        </div>
+        <div>
+          <dt>Total attempts</dt>
+          <dd id="stat-attempts">0</dd>
+        </div>
+        <div>
+          <dt>Error corrections</dt>
+          <dd id="stat-errors">0</dd>
+        </div>
+        <div>
+          <dt>Focused time</dt>
+          <dd id="stat-time">0s</dd>
+        </div>
+      </dl>
+    </footer>
+  </main>
+
+  <script src="assets/js/empathy-sim.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone empathy-challenge.html page with four guided empathy exercises
- create scoped styling and script modules for the compounding empathy interactions and progress tracking

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68dd31f7b41483208237e1b6e137a8d6